### PR TITLE
fix(request host): Removig hardcoded host from frontend request

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -20,9 +20,9 @@
 	<!-- Creating a div that will be used by the SDK to embed the dashboard -->
 	<div id="dashboard-container"></div>
 	<script>
-		// 1. Request guest_token from our backend, which runs at localhost:5000 by default 
+		// 1. Request guest_token from our backend
 		async function fetchGuestTokenFromBackend() {
-			let response = await fetch('http://127.0.0.1:8080/guest-token');
+			let response = await fetch('/guest-token');
 			let data = await response.json()
 			if (data["error"]){
 				alert("ERROR: " + data.error);
@@ -32,9 +32,8 @@
 		}
 
 		// 2. Uses Preset Embedded SDK to embed the dashboard as an iFrame
-		
 		const dashboardId = "{{ dashboardId }}";
-    	const supersetDomain = "{{ supersetDomain }}";
+		const supersetDomain = "{{ supersetDomain }}";
 
 		const myLightDashboard = presetSdk.embedDashboard({
 			id: dashboardId,


### PR DESCRIPTION
Hardcoding the host in the frontend request was not ideal when the app was running in a different port, and could also cause CORS issues when accessing the app using `localhost` (rather than `127.0.0.1`). 

With this change, the frontend would hit the `/guest-token` path based on the host and port currently being used. 