### PR TITLE
Document dashboard theme mode configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,47 @@ const myLightDashboard = presetSdk.embedDashboard({
 });
 ```
 
+### Setting the dashboard theme mode
+
+By default, an embedded dashboard renders using the Workspace default theme. You can specify which theme mode should be used by passing the `themeMode` URL parameter:
+
+```javascript
+const myLightDashboard = presetSdk.embedDashboard({
+  id: dashboardId,
+  supersetDomain: supersetDomain,
+  mountPoint: document.getElementById("dashboard-container"),
+  fetchGuestToken: async () => fetchGuestTokenFromBackend(),
+  dashboardUiConfig: {
+    urlParams: {
+      "themeMode": "dark", // "default", "dark" or "system"
+    }
+  }
+});
+```
+
+The accepted values are:
+* `default`: uses the Workspace default theme.
+* `dark`: renders the dashboard in dark mode.
+* `system`: follows the operating system preference of the user viewing the dashboard.
+
+The theme mode is applied while the dashboard loads, so the dashboard doesn't render in one mode and then switch to another.
+
+If your application has its own light/dark preference, pass `default` or `dark` explicitly based on that preference rather than using `system`. The `system` value follows the operating system setting, which can differ from the mode your application is currently displaying.
+
+#### Changing the theme mode after the dashboard has loaded
+
+It's also possible to change the theme mode after the dashboard has loaded, by calling the `setThemeMode()` method on the resolved dashboard instance. This is useful if your application allows users to switch between light and dark without reloading the page:
+
+``` javascript
+const dashboardElement = await myLightDashboard; // `myLightDashboard` is a promise that resolves to the dashboard instance
+
+...
+
+dashboardElement.setThemeMode("dark"); // "default", "dark" or "system"
+```
+
+Note that `setThemeMode()` can only take effect after the embedded application has loaded. Use the `themeMode` URL parameter to control which mode the dashboard renders in initially, and `setThemeMode()` for changes afterwards. The two can be combined.
+
 ### Managing the dashboard filter state
 
 By default, a dashboard is loaded in Embedded mode with its default filter configuration. It's possible to pass a `permalink_key` to load the dashboard with a particular filter configuration:


### PR DESCRIPTION
The README currently has no documentation for embedded dashboard theming. This adds a section covering:

- Setting the theme mode at load time via the `themeMode` URL parameter, with the accepted values and guidance on choosing between `system` and an explicit value.
- Changing the theme mode after load with `setThemeMode()`, and how the two relate.

Placed alongside the other `urlParams` sections, following the existing structure and code sample style.

### Verified

Tested with `@preset-sdk/embedded@0.3.2` against Preset Cloud workspaces in multiple regions:

- `themeMode: "dark"` passed via `dashboardUiConfig.urlParams` renders the dashboard in dark mode with no `setThemeMode()` call.
- A control run with no `themeMode` parameter renders in the Workspace default theme (light), confirming the parameter is what changes the behaviour.
- Verified with only `themeMode` in `urlParams`, so the documented snippet matches exactly what was tested.

Raised by a customer embedding dashboards in a dark-themed portal.